### PR TITLE
refactor: modify compose.yml and config.py to read from .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,6 @@ services:
       - .:/usr/src/app
     env_file:
       - .env
-    environment:
-      - FLASK_DEBUG=1
-      - APP_SETTINGS=project.server.config.DevelopmentConfig
-      - DATABASE_URL=postgresql://postgres:postgres@users-db:5432/users_dev
-      - DATABASE_TEST_URL=postgresql://postgres:postgres@users-db:5432/users_test
-      - SECRET_KEY=my_secret_key
     depends_on:
       - users-db
 
@@ -27,21 +21,17 @@ services:
       dockerfile: Dockerfile
     expose:
       - 5432
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+    env_file:
+      - .env
+    
 
   worker:
     image: users
     command: python manage.py run_worker
     volumes:
       - .:/usr/src/app
-    environment:
-      - FLASK_DEBUG=1
-      - APP_SETTINGS=project.server.config.DevelopmentConfig
-      - DATABASE_URL=postgresql://postgres:postgres@users-db:5432/users_dev
-      - DATABASE_TEST_URL=postgresql://postgres:postgres@users-db:5432/users_test
-      - SECRET_KEY=my_secret_key
+    env_file:
+      - .env
     depends_on:
       - users-db
       - redis

--- a/project/server/config.py
+++ b/project/server/config.py
@@ -11,7 +11,7 @@ class BaseConfig(object):
     SECRET_KEY = os.environ.get('SECRET_KEY')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     WTF_CSRF_ENABLED = False
-    REDIS_URL = 'redis://redis:6379/0'
+    REDIS_URL = os.environ.get('REDIS_URL')
     QUEUES = ['default']
     SECURITY_PASSWORD_SALT='email_confirmation_salt'
 


### PR DESCRIPTION
### What does this PR do?

- Updates `compose.yml` and `config.py` to read environment variables from `.env` file instead of passing the values directly.

### Related issue(s)?
- Resolves #26 