### PR TITLE
feat: add rq dashboard for monitoring redis queue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-
   users:
     build: .
     image: users
@@ -23,7 +22,6 @@ services:
       - 5432
     env_file:
       - .env
-    
 
   worker:
     image: users
@@ -38,3 +36,18 @@ services:
 
   redis:
     image: redis:6-alpine
+
+  dashboard:
+    build:
+      context: ./project/dashboard
+      dockerfile: Dockerfile
+    image: dashboard
+    container_name: rq_dashboard
+    # expose: 
+    #   - 9181
+    ports:
+      - 9181:9181
+    command: rq-dashboard -H redis
+    depends_on:
+      - redis
+    

--- a/project/dashboard/Dockerfile
+++ b/project/dashboard/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10.0-slim-buster
+
+# Install Flask, specifying a version compatible with rq-dashboard
+RUN pip install Flask==2.0.3 Werkzeug==2.0.3
+
+# Uninstall click if it's already installed
+RUN pip uninstall -y click
+
+# Install rq-dashboard and a compatible version of click
+# click breaks workers: https://github.com/rq/rq/issues/1469; pin click version
+RUN pip install rq-dashboard==0.5.1 click==7.1.2
+
+EXPOSE 9181
+
+CMD ["rq-dashboard"]


### PR DESCRIPTION
### What does this PR do?
- Created `Dockerfile` to set up `rq-dahsboard` (extra dependencies added for version compatibility)
- Added dashboard service to `compose.yml` specifying host as redis service

### Related issue?
- Resolves #28 

